### PR TITLE
Use absolute path for ledger entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apk add ledger
 # Add the source (1) to the filesystem at the destination (2).
 #ADD . /app
 
-ENTRYPOINT [ "./usr/bin/ledger" ]
+ENTRYPOINT [ "/usr/bin/ledger" ]


### PR DESCRIPTION
This allows for setting a different `WORKDIR` than root (`/`).