### PR TITLE
Use more conventional MIT license form

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Albert Albala
+Copyright (c) 2019 Albert Albala
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,22 +1,21 @@
-The MIT License
-===============
+MIT License
 
-> Copyright (c) Albert Albala
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
+Copyright (c) 2024 Albert Albala
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
I had steered @dcycle towards this license choice (#16) using https://github.com/intel352/vagrant-shell-scripts/blob/master/LICENSE.md as a sample to adapt, **however** it is formatted unconventionally and the [licensee](https://github.com/licensee/licensee) license detector [GitHub uses](https://docs.github.com/en/rest/licenses/licenses) does not identify it properly. So alas, GitHub didn't identify the license as MIT automatically. **Sorry about that!**

<img width="1207" alt="image" src="https://github.com/user-attachments/assets/aff4c35a-6473-4695-a2fd-f5557c1ed4a5">

**Instead**, use a version derived directly from the text in https://opensource.org/license/mit

(_also_ specify the copyright date of _original publication_  per [trijezdci](https://stackoverflow.com/users/231202/trijezdci)'s answer to the question [Do copyright dates need to be updated?](https://stackoverflow.com/questions/2390230/do-copyright-dates-need-to-be-updated))


## Test

```
$ git log -1
commit bc21b834d6deb74e7446a5bf0d8afee573e40cf3 (HEAD -> master, upstream/master, upstream/HEAD)
Author: Albert Albala <albert@mediatribe.net>
Date:   Sun Dec 1 12:47:18 2024 -0500

    #16 Create LICENSE.md
$ licensee
License:        NOASSERTION
Matched files:  LICENSE.md
LICENSE.md:
  Content hash:  0ff336b75323d180cd64342215d6c81f8e8deb0e
  License:       NOASSERTION
  Closest non-matching licenses:
    MIT similarity:    96.37%
    MIT-0 similarity:  73.68%
    NCSA similarity:   58.47%
$ git checkout fix-mit-license
Switched to branch 'fix-mit-license'
Your branch is up to date with 'origin/fix-mit-license'.
$ licensee
License:        MIT
Matched files:  LICENSE.md
LICENSE.md:
  Content hash:  4c2c763d64bbc7ef2e58b0ec6d06d90cee9755c9
  Attribution:   Copyright (c) 2019 Albert Albala
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
```