### PR TITLE
Use HTTPS CDN for Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# Docker microimage based on Alpine Linux.
+# Docker microimage for ledger based on Alpine Linux.
 FROM alpine:edge
-# Add the edge and testing repositories.
-RUN echo "http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+# Add the edge repository, use global Alpine CDN mirror.
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
   apk update && \
   apk upgrade && \
   apk add ledger


### PR DESCRIPTION
Resolves #6 

Uses the first mirror from https://mirrors.alpinelinux.org/ - a CDN with HTTPS

Thanks @alensiljak for the suggestion!